### PR TITLE
Add parsing of workspace.metadata.i18n

### DIFF
--- a/crates/support/src/config.rs
+++ b/crates/support/src/config.rs
@@ -63,10 +63,21 @@ impl I18nConfig {
     }
 
     pub fn parse(contents: &str) -> io::Result<Self> {
-        if !contents.contains("[i18n]") && !contents.contains("[package.metadata.i18n]") {
+        let package_metadata = contents.contains("[package.metadata.i18n]");
+        let workspace_metadata = contents.contains("[workspace.metadata.i18n]");
+
+        if !contents.contains("[i18n]") && !package_metadata && !workspace_metadata {
             return Ok(I18nConfig::default());
         }
-        let contents = contents.replace("[package.metadata.i18n]", "[i18n]");
+
+        let contents = if package_metadata {
+            contents.replace("[package.metadata.i18n]", "[i18n]")
+        } else if workspace_metadata {
+            contents.replace("[workspace.metadata.i18n]", "[i18n]")
+        } else {
+            contents.to_string()
+        };
+
         let mut config: MainConfig = toml::from_str(&contents)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 


### PR DESCRIPTION
minor changes


The current cli only supports reading `[package.metadata.i18n]`, but when there is no package entry in the project root, but there is `[workspace.metadata.i18n]` data, the available-locales and the available-locales are not read based on the attributes in the workspace. default-locale, resulting in a TODO that only detects `en` when executing `cargo i18n` in other languages.

For example, when this is the case:

https://github.com/longbridgeapp/rust-i18n/tree/84ac7dbb598f39901cd5fbc511664ae3cc36b4c1/examples/share-in-workspace


Although it is possible to pass the specified parameters by adding `[i18n]` directly to `Cargo.toml`, it is annoying to be prompted with a warning when executing `cargo build` or other commands! 

![image](https://github.com/user-attachments/assets/24c443f8-995f-4bd4-b87f-2a683e51d85b)

