### PR TITLE
Convert Backend's &str to Cow instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ For example, you can use HTTP API for load translations from remote server:
 #  }
 # }
 # use std::collections::HashMap;
+# use std::borrow::Cow;
 use rust_i18n::Backend;
 
 pub struct RemoteI18n {
@@ -273,14 +274,14 @@ impl RemoteI18n {
 }
 
 impl Backend for RemoteI18n {
-    fn available_locales(&self) -> Vec<&str> {
-        return self.trs.keys().map(|k| k.as_str()).collect();
+    fn available_locales(&self) -> Vec<Cow<'_, str>> {
+        return self.trs.keys().map(|k| Cow::from(k.as_str())).collect();
     }
 
-    fn translate(&self, locale: &str, key: &str) -> Option<&str> {
+    fn translate(&self, locale: &str, key: &str) -> Option<Cow<'_, str>> {
         // Write your own lookup logic here.
         // For example load from database
-        return self.trs.get(locale)?.get(key).map(|k| k.as_str());
+        return self.trs.get(locale)?.get(key).map(|k| Cow::from(k.as_str()));
     }
 }
 ```
@@ -293,8 +294,8 @@ Now you can init rust_i18n by extend your own backend:
 #   fn new() -> Self { todo!() }
 # }
 # impl rust_i18n::Backend for RemoteI18n {
-#   fn available_locales(&self) -> Vec<&str> { todo!() }
-#   fn translate(&self, locale: &str, key: &str) -> Option<&str> { todo!() }
+#   fn available_locales(&self) -> Vec<std::borrow::Cow<'_, str>> { todo!() }
+#   fn translate(&self, locale: &str, key: &str) -> Option<std::borrow::Cow<'_, str>> { todo!() }
 # }
 rust_i18n::i18n!("locales", backend = RemoteI18n::new());
 ```

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -319,7 +319,6 @@ fn generate_code(
 
     quote! {
         use rust_i18n::{BackendExt, CowStr, MinifyKey};
-        use std::borrow::Cow;
 
         /// I18n backend instance
         ///
@@ -356,7 +355,7 @@ fn generate_code(
         #[inline]
         #[allow(missing_docs)]
         #[doc(hidden)]
-        pub fn _rust_i18n_translate<'r>(locale: &str, key: &'r str) -> Cow<'r, str> {
+        pub fn _rust_i18n_translate<'r>(locale: &str, key: &'r str) -> std::borrow::Cow<'r, str> {
             _rust_i18n_try_translate(locale, key).unwrap_or_else(|| {
                 if locale.is_empty() {
                     key.into()
@@ -370,20 +369,19 @@ fn generate_code(
         #[inline]
         #[doc(hidden)]
         #[allow(missing_docs)]
-        pub fn _rust_i18n_try_translate<'r>(locale: &str, key: impl AsRef<str>) -> Option<Cow<'r, str>> {
+        pub fn _rust_i18n_try_translate<'r>(locale: &str, key: impl AsRef<str>) -> Option<std::borrow::Cow<'r, str>> {
             _RUST_I18N_BACKEND.translate(locale, key.as_ref())
-                .map(Cow::from)
                 .or_else(|| {
                     let mut current_locale = locale;
                     while let Some(fallback_locale) = _rust_i18n_lookup_fallback(current_locale) {
                         if let Some(value) = _RUST_I18N_BACKEND.translate(fallback_locale, key.as_ref()) {
-                            return Some(Cow::from(value));
+                            return Some(value);
                         }
                         current_locale = fallback_locale;
                     }
 
                     _RUST_I18N_FALLBACK_LOCALE.and_then(|fallback| {
-                        fallback.iter().find_map(|locale| _RUST_I18N_BACKEND.translate(locale, key.as_ref()).map(Cow::from))
+                        fallback.iter().find_map(|locale| _RUST_I18N_BACKEND.translate(locale, key.as_ref()))
                     })
                 })
         }
@@ -391,7 +389,7 @@ fn generate_code(
         #[inline]
         #[doc(hidden)]
         #[allow(missing_docs)]
-        pub fn _rust_i18n_available_locales() -> Vec<&'static str> {
+        pub fn _rust_i18n_available_locales() -> Vec<std::borrow::Cow<'static, str>> {
             let mut locales = _RUST_I18N_BACKEND.available_locales();
             locales.sort();
             locales

--- a/examples/app-egui/src/main.rs
+++ b/examples/app-egui/src/main.rs
@@ -67,7 +67,7 @@ impl eframe::App for MyApp {
                 let locales = rust_i18n::available_locales!();
                 for (i, locale) in locales.iter().enumerate() {
                     if ui
-                        .selectable_value(&mut self.locale_id, i, *locale)
+                        .selectable_value(&mut self.locale_id, i, locale.clone())
                         .changed()
                     {
                         rust_i18n::set_locale(locale);

--- a/examples/share-in-workspace/crates/i18n/src/lib.rs
+++ b/examples/share-in-workspace/crates/i18n/src/lib.rs
@@ -1,15 +1,16 @@
 use rust_i18n::Backend;
+use std::borrow::Cow;
 
 rust_i18n::i18n!("../../locales");
 
 pub struct I18nBackend;
 
 impl Backend for I18nBackend {
-    fn available_locales(&self) -> Vec<&str> {
+    fn available_locales(&self) -> Vec<Cow<'_, str>> {
         _RUST_I18N_BACKEND.available_locales()
     }
 
-    fn translate(&self, locale: &str, key: &str) -> Option<&str> {
+    fn translate(&self, locale: &str, key: &str) -> Option<Cow<'_, str>> {
         let val = _RUST_I18N_BACKEND.translate(locale, key);
         if val.is_none() {
             _RUST_I18N_BACKEND.translate("en", key)

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 struct TestBackend {
     trs: HashMap<String, String>,
@@ -13,13 +13,13 @@ impl TestBackend {
 }
 
 impl rust_i18n::Backend for TestBackend {
-    fn available_locales(&self) -> Vec<&str> {
-        vec!["pt", "en"]
+    fn available_locales(&self) -> Vec<Cow<'_, str>> {
+        vec![Cow::from("pt"), Cow::from("en")]
     }
 
-    fn translate(&self, locale: &str, key: &str) -> Option<&str> {
+    fn translate(&self, locale: &str, key: &str) -> Option<Cow<'_, str>> {
         if locale == "pt" {
-            return self.trs.get(key).map(|v| v.as_str());
+            return self.trs.get(key).map(|v| Cow::from(v.as_str()));
         }
         None
     }

--- a/tests/multi_threading.rs
+++ b/tests/multi_threading.rs
@@ -59,7 +59,7 @@ fn test_t_concurrent() {
                         if m == 0 {
                             t!("hello");
                         } else {
-                            t!("hello", locale = locales[m]);
+                            t!("hello", locale = &locales[m]);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/longbridge/rust-i18n/issues/44 

This is a breaking change to the `Backend` trait, but it stems from the realization that the `i18n` macro expansion always would call `Cow::from` on the result of both `available_locales` as well as `translate`.

This PR just moves that responsibility over to the `Backend` trait directly, this unlocks exactly the "reloadable" backend that the original issue was talking about.

## Before

```rust
pub trait Backend: Send + Sync + 'static {
    /// Return the available locales
    fn available_locales(&self) -> Vec<&str>;
    /// Get the translation for the given locale and key
    fn translate(&self, locale: &str, key: &str) -> Option<&str>;
}
```

## After

```rust
pub trait Backend: Send + Sync + 'static {
    /// Return the available locales
    fn available_locales(&self) -> Vec<Cow<'_, str>>;
    /// Get the translation for the given locale and key
    fn translate(&self, locale: &str, key: &str) -> Option<Cow<'_, str>>;
}
```

