### PR TITLE
📋 Add error message when parsing fails

### DIFF
--- a/crates/support/src/lib.rs
+++ b/crates/support/src/lib.rs
@@ -106,7 +106,7 @@ pub fn load_locales<F: Fn(&str) -> bool>(
             .expect("Read file failed.");
 
         let trs = parse_file(&content, ext, locale)
-            .unwrap_or_else(|_| panic!("Parse file `{}` failed", entry.display()));
+            .unwrap_or_else(|e| panic!("Parse file `{}` failed, reason: {}", entry.display(), e));
 
         trs.into_iter().for_each(|(k, new_value)| {
             translations


### PR DESCRIPTION
Fixes #97

This just implements the suggestion from the issue.